### PR TITLE
Create Navigator start up error (no constructor)

### DIFF
--- a/Navigator start up error (no constructor)
+++ b/Navigator start up error (no constructor)
@@ -1,0 +1,65 @@
+Navigator Error
+
+An unexpected error occurred on Navigator start-up
+
+Report
+
+Please report this issue in the anaconda issue tracker
+
+Main Error
+
+could not determine a constructor for the tag 'tag:yaml.org,2002:python/unicode'
+  in "/Users/nfortune/Library/Application Support/binstar/config.yaml", line 1, column 1
+Traceback
+
+Traceback (most recent call last):
+  File "/Users/nfortune/anaconda3/lib/python3.6/site-packages/anaconda_navigator/exceptions.py", line 75, in exception_handler
+    return_value = func(*args, **kwargs)
+  File "/Users/nfortune/anaconda3/lib/python3.6/site-packages/anaconda_navigator/app/start.py", line 120, in start_app
+    window = run_app(splash)
+  File "/Users/nfortune/anaconda3/lib/python3.6/site-packages/anaconda_navigator/app/start.py", line 63, in run_app
+    window = MainWindow(splash=splash)
+  File "/Users/nfortune/anaconda3/lib/python3.6/site-packages/anaconda_navigator/widgets/main_window.py", line 163, in __init__
+    self.api = AnacondaAPI()
+  File "/Users/nfortune/anaconda3/lib/python3.6/site-packages/anaconda_navigator/api/anaconda_api.py", line 2004, in AnacondaAPI
+    ANACONDA_API = _AnacondaAPI()
+  File "/Users/nfortune/anaconda3/lib/python3.6/site-packages/anaconda_navigator/api/anaconda_api.py", line 89, in __init__
+    self._client_api = ClientAPI()
+  File "/Users/nfortune/anaconda3/lib/python3.6/site-packages/anaconda_navigator/api/client_api.py", line 612, in ClientAPI
+    CLIENT_API = _ClientAPI()
+  File "/Users/nfortune/anaconda3/lib/python3.6/site-packages/anaconda_navigator/api/client_api.py", line 82, in __init__
+    log_level=logging.NOTSET
+  File "/Users/nfortune/anaconda3/lib/python3.6/site-packages/binstar_client/utils/config.py", line 96, in get_server_api
+    config = get_config(remote_site=site)
+  File "/Users/nfortune/anaconda3/lib/python3.6/site-packages/binstar_client/utils/config.py", line 229, in get_config
+    file_configs = load_file_configs(SEARCH_PATH)
+  File "/Users/nfortune/anaconda3/lib/python3.6/site-packages/binstar_client/utils/config.py", line 223, in load_file_configs
+    raw_data = collections.OrderedDict(kv for kv in itertools.chain.from_iterable(load_paths))
+  File "/Users/nfortune/anaconda3/lib/python3.6/site-packages/binstar_client/utils/config.py", line 223, in 
+    raw_data = collections.OrderedDict(kv for kv in itertools.chain.from_iterable(load_paths))
+  File "/Users/nfortune/anaconda3/lib/python3.6/site-packages/binstar_client/utils/config.py", line 203, in _dir_yaml_loader
+    yield filepath, load_config(filepath)
+  File "/Users/nfortune/anaconda3/lib/python3.6/site-packages/binstar_client/utils/config.py", line 187, in load_config
+    data = yaml_load(fd)
+  File "/Users/nfortune/anaconda3/lib/python3.6/site-packages/binstar_client/utils/yaml.py", line 9, in yaml_load
+    return safe_load(stream)
+  File "/Users/nfortune/anaconda3/lib/python3.6/site-packages/yaml/__init__.py", line 94, in safe_load
+    return load(stream, SafeLoader)
+  File "/Users/nfortune/anaconda3/lib/python3.6/site-packages/yaml/__init__.py", line 72, in load
+    return loader.get_single_data()
+  File "/Users/nfortune/anaconda3/lib/python3.6/site-packages/yaml/constructor.py", line 37, in get_single_data
+    return self.construct_document(node)
+  File "/Users/nfortune/anaconda3/lib/python3.6/site-packages/yaml/constructor.py", line 46, in construct_document
+    for dummy in generator:
+  File "/Users/nfortune/anaconda3/lib/python3.6/site-packages/yaml/constructor.py", line 398, in construct_yaml_map
+    value = self.construct_mapping(node)
+  File "/Users/nfortune/anaconda3/lib/python3.6/site-packages/yaml/constructor.py", line 204, in construct_mapping
+    return super().construct_mapping(node, deep=deep)
+  File "/Users/nfortune/anaconda3/lib/python3.6/site-packages/yaml/constructor.py", line 125, in construct_mapping
+    key = self.construct_object(key_node, deep=deep)
+  File "/Users/nfortune/anaconda3/lib/python3.6/site-packages/yaml/constructor.py", line 86, in construct_object
+    data = constructor(self, node)
+  File "/Users/nfortune/anaconda3/lib/python3.6/site-packages/yaml/constructor.py", line 414, in construct_undefined
+    node.start_mark)
+yaml.constructor.ConstructorError: could not determine a constructor for the tag 'tag:yaml.org,2002:python/unicode'
+  in "/Users/nfortune/Library/Application Support/binstar/config.yaml", line 1, column 1


### PR DESCRIPTION
error message on start up after installation of Anaconda Navigator 5.1 on Mac OS