### PR TITLE
Improve templates readme

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,41 +1,65 @@
 <!--
-Thanks for opening an issue! A few things to keep in mind:
+Thanks for opening an issue! Please fill out the following template in full.
 
-- This issue tracker is for issues with installing Anaconda or Miniconda or 
-with packages built by Anaconda, Inc. like Anaconda Navigator. It is also a 
+A few things to keep in mind:
+
+- This issue tracker is for issues with installing Anaconda or Miniconda or
+with packages built by Anaconda, Inc. like Anaconda Navigator. It is also a
 place to request packages or other enhancements of the Anaconda Distribution.
 
-For conda issues, you should open an issue at https://github.com/conda/conda/issues
-For conda-build issues, you should open an issue at https://github.com/conda/conda-build
-For an issue with a particular conda-forge package, you should open an issue on the 
-corresponding feedstock: https://github.com/conda-forge
+- For conda issues, you should open an issue at https://github.com/conda/conda/issues
+- For conda-build issues, you should open an issue at https://github.com/conda/conda-build
+- For an issue with a particular conda-forge package, you should open an issue
+on the corresponding feedstock: https://github.com/conda-forge
 -->
 
 ### Actual Behavior
 
 <!-- What actually happens? -->
 
+
+
 ### Expected Behavior
 
 <!-- What do you think should happen? -->
 
+
+
 ### Steps to Reproduce
 
-<!-- Steps to reproduce issue. -->
+<!-- What steps will reproduce the issue? -->
+
 
 
 ##### Anaconda or Miniconda version:
 
+<!--
+This is the version number in the filename of the package you downloaded,
+NOT your Python version, Anaconda navigator version or Conda version.
+-->
+
 ##### Operating System:
 
 ##### `conda info`
-<!-- between the ticks below, paste the output of 'conda info' -->
-```
+<!-- Paste the output of 'conda info' between the two sets of backticks (```) below -->
+
+<details>
 
 ```
+PASTE OUTPUT HERE:
+
+```
+
+</details>
 
 ##### `conda list --show-channel-urls`
-<!-- between the ticks below, paste the output of 'conda list --show-channel-urls' -->
-```
+<!-- Paste the output of 'conda list --show-channel-urls' between the two sets of backticks (```) below -->
+
+<details>
 
 ```
+PASTE OUTPUT HERE:
+
+```
+
+</details>

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,2 @@
+<!-- *Please* do not use pull requests to report problems with Anaconda. -->
+<!-- Fill out an issue report under the Issues tab instead. Thanks!      -->

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-Please submit Anaconda issues to the
-[issue tracker](https://github.com/ContinuumIO/anaconda-issues/issues) of this
-repository.
+Please submit Anaconda issues to the [issue tracker](
+https://github.com/ContinuumIO/anaconda-issues/issues) of this repository.
 
-Note, this issue tracker is for issues with the
-[Anaconda](https://store.continuum.io/cshop/anaconda/) Python distribution,
-its installers, and its packages.  For issues with the
-[conda](http://conda.pydata.org/) package manager, unrelated to any specific
-package, please use the
-[conda issue tracker](https://github.com/conda/conda/issues).
+Note: this issue tracker is for issues with the [Anaconda](
+https://store.continuum.io/cshop/anaconda/) Python distribution,
+its installers, and its packages.
+For issues with the [Conda](https://conda.io/) package manager
+unrelated to any specific package, please use the
+[Conda issue tracker](https://github.com/conda/conda/issues).
 
-To download Anaconda, go to http://continuum.io/downloads.
+To download Anaconda, visit the [Anaconda download page](
+https://www.anaconda.com/distribution/).


### PR DESCRIPTION
Primarily begun just to add ``<details>`` tags to the otherwise unwieldy-long ``conda info`` and particularly ``conda list`` sections, I ended up updating several old/non-HTTPS links, adding some clarifications (and a PR template) based on some problems I noticed on other issues, and implementing some minor formatting/copyediting fixes.